### PR TITLE
feature/multi-stage-dockerfile

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,6 @@
+# Discord
+DISCORD_KEY=
+
+# Sonarr
+SONARR_URL=
+SONARR_API_KEY=

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ node_modules/
 *.iml
 secrets/
 coverage/
+.env

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,14 +1,26 @@
-FROM node:10.16.0-alpine
+FROM node:10.16.0-alpine AS base
 WORKDIR /usr/src/app
 
-COPY package*.json ./
+# development
+FROM base AS dev
+RUN npm install typescript -g
 
-RUN npm install --only-production\
-    && npm install typescript -g
-
+# build
+FROM dev as build
 COPY . .
-
+RUN npm install --only-production
 RUN tsc
+
+# production
+FROM base as prod
+
+COPY --from=build \
+    /usr/src/app/dist \
+    /usr/src/app/dist
+
+COPY --from=build \
+    /usr/src/app/node_modules \
+    /usr/src/app/node_modules
 
 CMD ["node", "dist/index.js"]
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,9 @@
+version: '2.4'
+
+services:
+  app:
+    build:
+      context: .
+      target: dev
+    volumes:
+      - .:/usr/src/app

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,5 +5,7 @@ services:
     build:
       context: .
       target: dev
+    env_file:
+      - .env
     volumes:
       - .:/usr/src/app


### PR DESCRIPTION
Split the dockerfile into multiple stages: dev, build & prod; also added docker-compose support for development.

**Explanation**
- base: bare minimal setup for project
- dev: development environment, this is so you won't need NodeJS or TypeScript installed locally. Works together with the `docker-compose.yml` file added.
- build: extends the dev image to build the final output files.
- prod: extends base image but copies the output from build, this is to save space.

**Benefits**
- Reduced production image size (232mb to 161mb)
- Quicker docker build times depending on stage
- Develop inside the container, no need for developers to pollute their host machine with TypeScript

**Extension**
From the 'build' stage added you could extend this image for unit testing. This way you can do all of your automated testing from within the container itself with minimal setup.